### PR TITLE
[performance improvement] Use INSERT ON CONFLICT DO NOTHING for Video inserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-06-18 - Replacing `SELECT` before `INSERT` with `INSERT ... ON CONFLICT DO NOTHING`
+
+**Optimization:** Replaced the pattern of checking for video existence with `SELECT` before inserting with `INSERT ... ON CONFLICT DO NOTHING` in `scraper/youtube_scraper.py`.
+**Learning:** This codebase relies heavily on unique constraints (`youtube_id`). The ORM-style full-object check (`select(Video)`) followed by an insert creates an N+1 round-trip bottleneck. By directly invoking `sqlalchemy.dialects.postgresql.insert` and utilizing `.on_conflict_do_nothing(index_elements=['youtube_id'])`, we can rely directly on the database to handle uniqueness in a single round-trip, yielding a massive win for bulk insertions from the scraper and eliminating the pre-insert check. This reduces DB query cost significantly and speeds up scraper throughput without breaking existing async session logic.
+**Measurement:** Replaced 2 queries per insert check with 1 query.

--- a/scraper/youtube_scraper.py
+++ b/scraper/youtube_scraper.py
@@ -54,7 +54,7 @@ async def get_video_details(video_ids):
 
 async def insert_video(video, subject="Science", difficulty="Easy", db_session=None):
     """Insert a video into the database. Uses provided AsyncSession or creates new one."""
-    from sqlalchemy import select
+    from sqlalchemy.dialects.postgresql import insert
 
     from backend.database import AsyncSessionLocal
     own_session = db_session is None
@@ -68,13 +68,9 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
         except Exception:
             duration_seconds = 0
 
-        result = await session.execute(select(Video).filter(Video.youtube_id == video['id']))
-        if result.scalars().first():
-            if own_session:
-                await session.close()
-            return False
-
-        video_record = Video(
+        # Optimization: use INSERT ... ON CONFLICT DO NOTHING to avoid a pre-insert SELECT
+        # Eliminates redundant DB round-trip on insertions.
+        stmt = insert(Video).values(
             youtube_id=video['id'],
             title=title,
             description=description,
@@ -85,11 +81,13 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
             view_count=int(video['statistics'].get('viewCount', 0)),
             like_count=int(video['statistics'].get('likeCount', 0)),
             embedding=None
-        )
-        session.add(video_record)
+        ).on_conflict_do_nothing(index_elements=['youtube_id'])
+
+        result = await session.execute(stmt)
         if own_session:
             await session.commit()
-        return True
+
+        return result.rowcount > 0
     except Exception:
         if own_session:
             await session.rollback()
@@ -105,10 +103,10 @@ def is_youtube_short(video):
         duration_seconds = int(isodate.parse_duration(video['contentDetails']['duration']).total_seconds())
     except Exception:
         return True  # Assume short if can't parse duration
-    
+
     title = video['snippet'].get('title', '').lower()
     description = video['snippet'].get('description', '').lower()
-    
+
     return duration_seconds < 60 or '#shorts' in title or '#shorts' in description
 
 
@@ -122,33 +120,32 @@ async def fetch_and_store_videos(query, max_results=20, video_duration="any", db
     """
     Fetch videos from YouTube API, filter out Shorts and non-educational,
     then store valid videos in the database.
-    
+
     Returns the count of newly inserted videos.
     """
     print(f"🔍 Fetching videos from YouTube for: '{query}'")
-    
+
     yt_results = await fetch_videos(query, max_results=max_results, video_duration=video_duration)
     video_ids = [item["id"]["videoId"] for item in yt_results if "videoId" in item.get("id", {})]
-    
+
     if not video_ids:
         print("⚠️ No video IDs returned from YouTube API.")
         return 0
-    
+
     video_details = await get_video_details(video_ids)
     inserted_count = 0
-    
+
     for video in video_details:
         if is_youtube_short(video):
             print(f"⏭️ Skipped Short: {video['snippet']['title'][:50]}")
             continue
-        
+
         if not is_educational_video(video):
             print(f"⏭️ Skipped non-educational: {video['snippet']['title'][:50]}")
             continue
-        
+
         if await insert_video(video, subject="Auto", difficulty="Medium", db_session=db_session):
             inserted_count += 1
-    
+
     print(f"✅ Inserted {inserted_count} educational videos into database.")
     return inserted_count
-


### PR DESCRIPTION
💡 **What:** The optimization implemented is replacing the N+1 `SELECT` check before inserting a video in `insert_video` (in `scraper/youtube_scraper.py`) with a single `INSERT ... ON CONFLICT DO NOTHING` statement using `sqlalchemy.dialects.postgresql.insert`.
🎯 **Why:** To eliminate the redundant database round-trip that occurs for every video insertion. The `youtube_id` column already has a unique index, so the database can handle duplicates seamlessly without needing a prior `SELECT` query.
📊 **Impact:** Replaces 2 queries per insert check with 1 query, significantly speeding up bulk insertions from the YouTube scraper.
🔬 **Measurement:** Replaced 2 queries per insert check with 1 query. Verified using a custom Python script checking `rowcount` correctness and logging execution. The changes were added to the `bolt.md` performance journal.

---
*PR created automatically by Jules for task [3490939768102160098](https://jules.google.com/task/3490939768102160098) started by @TouqeerHamdani*