### PR TITLE
[performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+
+## 2025-05-15 - [Database Performance] Use atomic insert for video deduplication
+**Vulnerability/Bottleneck:** The scraper previously executed a `SELECT` query for every video to check for duplicates before `INSERT`, effectively doubling the database round-trips for the background insertion task.
+**Learning:** For high-throughput scenarios (like background ingestion via `youtube_scraper.py`), `sqlalchemy.dialects.postgresql.insert` with `.on_conflict_do_nothing(index_elements=...)` is essential to minimize latency, particularly on unique constraints like `youtube_id`.
+**Prevention:** Avoid pre-insert existence checks via `SELECT` when atomic upsert/ignore mechanisms exist.

--- a/scraper/youtube_scraper.py
+++ b/scraper/youtube_scraper.py
@@ -54,7 +54,7 @@ async def get_video_details(video_ids):
 
 async def insert_video(video, subject="Science", difficulty="Easy", db_session=None):
     """Insert a video into the database. Uses provided AsyncSession or creates new one."""
-    from sqlalchemy import select
+    from sqlalchemy.dialects.postgresql import insert
 
     from backend.database import AsyncSessionLocal
     own_session = db_session is None
@@ -68,13 +68,8 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
         except Exception:
             duration_seconds = 0
 
-        result = await session.execute(select(Video).filter(Video.youtube_id == video['id']))
-        if result.scalars().first():
-            if own_session:
-                await session.close()
-            return False
-
-        video_record = Video(
+        # Avoids a pre-insert SELECT — uses ON CONFLICT DO NOTHING for atomic insert
+        stmt = insert(Video).values(
             youtube_id=video['id'],
             title=title,
             description=description,
@@ -85,11 +80,13 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
             view_count=int(video['statistics'].get('viewCount', 0)),
             like_count=int(video['statistics'].get('likeCount', 0)),
             embedding=None
-        )
-        session.add(video_record)
+        ).on_conflict_do_nothing(index_elements=['youtube_id'])
+
+        result = await session.execute(stmt)
         if own_session:
             await session.commit()
-        return True
+
+        return result.rowcount > 0
     except Exception:
         if own_session:
             await session.rollback()
@@ -105,10 +102,10 @@ def is_youtube_short(video):
         duration_seconds = int(isodate.parse_duration(video['contentDetails']['duration']).total_seconds())
     except Exception:
         return True  # Assume short if can't parse duration
-    
+
     title = video['snippet'].get('title', '').lower()
     description = video['snippet'].get('description', '').lower()
-    
+
     return duration_seconds < 60 or '#shorts' in title or '#shorts' in description
 
 
@@ -122,33 +119,32 @@ async def fetch_and_store_videos(query, max_results=20, video_duration="any", db
     """
     Fetch videos from YouTube API, filter out Shorts and non-educational,
     then store valid videos in the database.
-    
+
     Returns the count of newly inserted videos.
     """
     print(f"🔍 Fetching videos from YouTube for: '{query}'")
-    
+
     yt_results = await fetch_videos(query, max_results=max_results, video_duration=video_duration)
     video_ids = [item["id"]["videoId"] for item in yt_results if "videoId" in item.get("id", {})]
-    
+
     if not video_ids:
         print("⚠️ No video IDs returned from YouTube API.")
         return 0
-    
+
     video_details = await get_video_details(video_ids)
     inserted_count = 0
-    
+
     for video in video_details:
         if is_youtube_short(video):
             print(f"⏭️ Skipped Short: {video['snippet']['title'][:50]}")
             continue
-        
+
         if not is_educational_video(video):
             print(f"⏭️ Skipped non-educational: {video['snippet']['title'][:50]}")
             continue
-        
+
         if await insert_video(video, subject="Auto", difficulty="Medium", db_session=db_session):
             inserted_count += 1
-    
+
     print(f"✅ Inserted {inserted_count} educational videos into database.")
     return inserted_count
-


### PR DESCRIPTION
💡 What: Replace the `SELECT` existence check and subsequent `INSERT` with an atomic `INSERT ... ON CONFLICT DO NOTHING` query for `youtube_scraper.insert_video()`.
🎯 Why: The scraper background task executes these checks sequentially for each video; by removing the redundant `SELECT` query, database round-trips for duplicate videos are halved.
📊 Impact: Eliminates a redundant database round-trip on all video inserts. This is especially impactful because duplicates are extremely common during background ingestion.
🔬 Measurement: Verify the function correctly returns `True` only when new videos are inserted, and no duplicate `youtube_id` violation errors are logged when existing videos are fetched.

---
*PR created automatically by Jules for task [14308909278480854341](https://jules.google.com/task/14308909278480854341) started by @TouqeerHamdani*