### PR TITLE
[performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-03-21 - [Performance] Use `INSERT ... ON CONFLICT DO NOTHING` in Youtube Scraper
+**Vulnerability/Bottleneck:** Pre-insert SELECT round-trip in `scraper/youtube_scraper.py` on `insert_video` function causes performance degradation. The function does a full lookup by youtube_id and then does an insert, running two queries instead of one.
+**Learning:** For batch operations where many items may already exist in the database (e.g. repeated fetching of YouTube query results), it is more efficient to use PostgreSQL's native `INSERT ... ON CONFLICT DO NOTHING`.
+**Prevention:** Instead of using ORM `SELECT` then `INSERT` manually, always use the database-level conflict resolution features `sqlalchemy.dialects.postgresql.insert(Table).values(...).on_conflict_do_nothing()` for high-throughput unique constraint updates.

--- a/scraper/youtube_scraper.py
+++ b/scraper/youtube_scraper.py
@@ -54,7 +54,7 @@ async def get_video_details(video_ids):
 
 async def insert_video(video, subject="Science", difficulty="Easy", db_session=None):
     """Insert a video into the database. Uses provided AsyncSession or creates new one."""
-    from sqlalchemy import select
+    from sqlalchemy.dialects.postgresql import insert
 
     from backend.database import AsyncSessionLocal
     own_session = db_session is None
@@ -68,13 +68,8 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
         except Exception:
             duration_seconds = 0
 
-        result = await session.execute(select(Video).filter(Video.youtube_id == video['id']))
-        if result.scalars().first():
-            if own_session:
-                await session.close()
-            return False
-
-        video_record = Video(
+        # Avoids redundant SELECT round-trip for unique constraint check
+        stmt = insert(Video).values(
             youtube_id=video['id'],
             title=title,
             description=description,
@@ -85,11 +80,12 @@ async def insert_video(video, subject="Science", difficulty="Easy", db_session=N
             view_count=int(video['statistics'].get('viewCount', 0)),
             like_count=int(video['statistics'].get('likeCount', 0)),
             embedding=None
-        )
-        session.add(video_record)
+        ).on_conflict_do_nothing(index_elements=['youtube_id'])
+
+        result = await session.execute(stmt)
         if own_session:
             await session.commit()
-        return True
+        return result.rowcount > 0
     except Exception:
         if own_session:
             await session.rollback()
@@ -105,10 +101,10 @@ def is_youtube_short(video):
         duration_seconds = int(isodate.parse_duration(video['contentDetails']['duration']).total_seconds())
     except Exception:
         return True  # Assume short if can't parse duration
-    
+
     title = video['snippet'].get('title', '').lower()
     description = video['snippet'].get('description', '').lower()
-    
+
     return duration_seconds < 60 or '#shorts' in title or '#shorts' in description
 
 
@@ -122,33 +118,32 @@ async def fetch_and_store_videos(query, max_results=20, video_duration="any", db
     """
     Fetch videos from YouTube API, filter out Shorts and non-educational,
     then store valid videos in the database.
-    
+
     Returns the count of newly inserted videos.
     """
     print(f"🔍 Fetching videos from YouTube for: '{query}'")
-    
+
     yt_results = await fetch_videos(query, max_results=max_results, video_duration=video_duration)
     video_ids = [item["id"]["videoId"] for item in yt_results if "videoId" in item.get("id", {})]
-    
+
     if not video_ids:
         print("⚠️ No video IDs returned from YouTube API.")
         return 0
-    
+
     video_details = await get_video_details(video_ids)
     inserted_count = 0
-    
+
     for video in video_details:
         if is_youtube_short(video):
             print(f"⏭️ Skipped Short: {video['snippet']['title'][:50]}")
             continue
-        
+
         if not is_educational_video(video):
             print(f"⏭️ Skipped non-educational: {video['snippet']['title'][:50]}")
             continue
-        
+
         if await insert_video(video, subject="Auto", difficulty="Medium", db_session=db_session):
             inserted_count += 1
-    
+
     print(f"✅ Inserted {inserted_count} educational videos into database.")
     return inserted_count
-


### PR DESCRIPTION
💡 What: Replaced the two-step `SELECT` then `INSERT` in `insert_video` (`scraper/youtube_scraper.py`) with a single `INSERT ... ON CONFLICT DO NOTHING` query using `sqlalchemy.dialects.postgresql.insert`.
🎯 Why: The function was previously executing a full database lookup by `youtube_id` before inserting, running two queries instead of one (file `scraper/youtube_scraper.py`, `insert_video` function). This optimization eliminates a redundant DB round-trip on every duplicate insert.
📊 Impact: Eliminates a redundant DB round-trip on duplicate inserts during high-throughput scraper batch operations, which is the vast majority of requests on repeated queries.
🔬 Measurement: Verify via `pytest tests/` and database profiling showing single `INSERT` queries per video without preceding `SELECT`s. Also, `ruff check .` confirms no linting issues.

---
*PR created automatically by Jules for task [16882311568868348635](https://jules.google.com/task/16882311568868348635) started by @TouqeerHamdani*